### PR TITLE
fix(cache): 移除前端应用ID持久化缓存，确保配置立即对所有用户生效

### DIFF
--- a/lib/stores/current-app-store.ts
+++ b/lib/stores/current-app-store.ts
@@ -1,6 +1,5 @@
 // lib/stores/current-app-store.ts
 import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware';
 import { getProviderByName, getDefaultServiceInstance } from '@lib/db';
 import { Result } from '@lib/types/result';
 import type { ServiceInstance, Provider } from '@lib/types/database';
@@ -23,170 +22,157 @@ interface CurrentAppState {
 // --- END COMMENT ---
 const DIFY_PROVIDER_NAME = 'Dify'; 
 
-export const useCurrentAppStore = create<CurrentAppState>()(
-  persist(
-    (set, get) => ({
+export const useCurrentAppStore = create<CurrentAppState>()((set, get) => ({
+  currentAppId: null,
+  currentAppInstance: null,
+  isLoadingAppId: false,
+  errorLoadingAppId: null,
+  
+  setCurrentAppId: (appId, instance) => {
+    set({ 
+      currentAppId: appId, 
+      currentAppInstance: instance, 
+      isLoadingAppId: false, 
+      errorLoadingAppId: null 
+    });
+    // --- BEGIN COMMENT ---
+    // TODO (后续): 当 appId 改变时，可能需要触发相关数据的重新加载，
+    // 例如，对话列表 useConversations 可能需要根据新的 appId 刷新。
+    // 这可以通过在 useConversations 中也订阅 currentAppId 来实现，
+    // 或者在这里调用一个全局的刷新函数/事件。
+    // --- END COMMENT ---
+  },
+  
+  clearCurrentApp: () => {
+    set({
       currentAppId: null,
       currentAppInstance: null,
       isLoadingAppId: false,
       errorLoadingAppId: null,
-      
-      setCurrentAppId: (appId, instance) => {
-        set({ 
-          currentAppId: appId, 
-          currentAppInstance: instance, 
-          isLoadingAppId: false, 
-          errorLoadingAppId: null 
-        });
-        // --- BEGIN COMMENT ---
-        // TODO (后续): 当 appId 改变时，可能需要触发相关数据的重新加载，
-        // 例如，对话列表 useConversations 可能需要根据新的 appId 刷新。
-        // 这可以通过在 useConversations 中也订阅 currentAppId 来实现，
-        // 或者在这里调用一个全局的刷新函数/事件。
-        // --- END COMMENT ---
-      },
-      
-      clearCurrentApp: () => {
-        set({
-          currentAppId: null,
-          currentAppInstance: null,
-          isLoadingAppId: false,
-          errorLoadingAppId: null,
-        });
-      },
-      
-      initializeDefaultAppId: async (forceRefresh = false) => {
-        // 防止重复初始化，除非强制刷新
-        if (!forceRefresh && (get().currentAppId || get().isLoadingAppId)) {
-          return;
-        }
-        
-        set({ isLoadingAppId: true, errorLoadingAppId: null });
-        
-        try {
-          // --- BEGIN COMMENT ---
-          // 使用新版本的数据库接口，支持Result类型和错误处理
-          // --- END COMMENT ---
-          const providerResult = await getProviderByName(DIFY_PROVIDER_NAME);
-          
-          if (!providerResult.success) {
-            throw new Error(`获取提供商"${DIFY_PROVIDER_NAME}"失败: ${providerResult.error.message}`);
-          }
-          
-          if (!providerResult.data) {
-            throw new Error(`数据库中未找到提供商"${DIFY_PROVIDER_NAME}"`);
-          }
-
-          const defaultInstanceResult = await getDefaultServiceInstance(providerResult.data.id);
-          
-          if (!defaultInstanceResult.success) {
-            throw new Error(`获取默认服务实例失败: ${defaultInstanceResult.error.message}`);
-          }
-          
-          if (defaultInstanceResult.data && defaultInstanceResult.data.instance_id) {
-            set({
-              currentAppId: defaultInstanceResult.data.instance_id,
-              currentAppInstance: defaultInstanceResult.data,
-              isLoadingAppId: false,
-            });
-          } else {
-            // --- BEGIN COMMENT ---
-            // 如果数据库中没有配置默认的 Dify 应用实例，这是一个需要处理的场景。
-            // UI 层应该提示用户选择一个应用，或者管理员需要配置一个默认应用。
-            // 当前我们将 appId 设为 null，并记录错误。
-            // --- END COMMENT ---
-            const errorMessage = `未找到提供商"${DIFY_PROVIDER_NAME}"的默认服务实例。请配置一个默认的 Dify 应用。`;
-            console.warn(errorMessage);
-            set({ 
-              currentAppId: null, 
-              currentAppInstance: null, 
-              isLoadingAppId: false, 
-              errorLoadingAppId: errorMessage 
-            });
-          }
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          console.error("初始化默认应用ID失败:", errorMessage);
-          set({ 
-            isLoadingAppId: false, 
-            errorLoadingAppId: errorMessage 
-          });
-        }
-      },
-      
-      // --- BEGIN COMMENT ---
-      // 新增刷新当前应用的方法，用于重新获取最新的应用实例信息
-      // --- END COMMENT ---
-      refreshCurrentApp: async () => {
-        const currentState = get();
-        
-        if (!currentState.currentAppInstance) {
-          // 如果没有当前应用，尝试初始化默认应用
-          await get().initializeDefaultAppId();
-          return;
-        }
-        
-        set({ isLoadingAppId: true, errorLoadingAppId: null });
-        
-        try {
-          const defaultInstanceResult = await getDefaultServiceInstance(
-            currentState.currentAppInstance.provider_id
-          );
-          
-          if (!defaultInstanceResult.success) {
-            throw new Error(`刷新应用实例失败: ${defaultInstanceResult.error.message}`);
-          }
-          
-          if (defaultInstanceResult.data && defaultInstanceResult.data.instance_id) {
-            set({
-              currentAppId: defaultInstanceResult.data.instance_id,
-              currentAppInstance: defaultInstanceResult.data,
-              isLoadingAppId: false,
-            });
-          } else {
-            const errorMessage = "未找到默认服务实例";
-            set({ 
-              isLoadingAppId: false, 
-              errorLoadingAppId: errorMessage 
-            });
-          }
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          console.error("刷新当前应用失败:", errorMessage);
-          set({ 
-            isLoadingAppId: false, 
-            errorLoadingAppId: errorMessage 
-          });
-        }
-      },
-      
-      // --- BEGIN COMMENT ---
-      // 强制刷新默认应用，清除缓存并重新获取最新的默认应用
-      // --- END COMMENT ---
-      forceRefreshDefaultApp: async () => {
-        // 清除当前应用状态
-        set({
-          currentAppId: null,
-          currentAppInstance: null,
-          isLoadingAppId: false,
-          errorLoadingAppId: null,
-        });
-        
-        // 强制重新初始化
-        await get().initializeDefaultAppId(true);
-      },
-    }),
-    {
-      name: 'current-app-storage', // localStorage 中的 key
-      storage: createJSONStorage(() => localStorage),
-      // 只持久化 appId 和 instance，其他状态是临时的
-      partialize: (state) => ({ 
-        currentAppId: state.currentAppId, 
-        currentAppInstance: state.currentAppInstance 
-      }), 
+    });
+  },
+  
+  initializeDefaultAppId: async (forceRefresh = false) => {
+    // 防止重复初始化，除非强制刷新
+    if (!forceRefresh && (get().currentAppId || get().isLoadingAppId)) {
+      return;
     }
-  )
-);
+    
+    set({ isLoadingAppId: true, errorLoadingAppId: null });
+    
+    try {
+      // --- BEGIN COMMENT ---
+      // 使用新版本的数据库接口，支持Result类型和错误处理
+      // --- END COMMENT ---
+      const providerResult = await getProviderByName(DIFY_PROVIDER_NAME);
+      
+      if (!providerResult.success) {
+        throw new Error(`获取提供商"${DIFY_PROVIDER_NAME}"失败: ${providerResult.error.message}`);
+      }
+      
+      if (!providerResult.data) {
+        throw new Error(`数据库中未找到提供商"${DIFY_PROVIDER_NAME}"`);
+      }
+
+      const defaultInstanceResult = await getDefaultServiceInstance(providerResult.data.id);
+      
+      if (!defaultInstanceResult.success) {
+        throw new Error(`获取默认服务实例失败: ${defaultInstanceResult.error.message}`);
+      }
+      
+      if (defaultInstanceResult.data && defaultInstanceResult.data.instance_id) {
+        set({
+          currentAppId: defaultInstanceResult.data.instance_id,
+          currentAppInstance: defaultInstanceResult.data,
+          isLoadingAppId: false,
+        });
+      } else {
+        // --- BEGIN COMMENT ---
+        // 如果数据库中没有配置默认的 Dify 应用实例，这是一个需要处理的场景。
+        // UI 层应该提示用户选择一个应用，或者管理员需要配置一个默认应用。
+        // 当前我们将 appId 设为 null，并记录错误。
+        // --- END COMMENT ---
+        const errorMessage = `未找到提供商"${DIFY_PROVIDER_NAME}"的默认服务实例。请配置一个默认的 Dify 应用。`;
+        console.warn(errorMessage);
+        set({ 
+          currentAppId: null, 
+          currentAppInstance: null, 
+          isLoadingAppId: false, 
+          errorLoadingAppId: errorMessage 
+        });
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error("初始化默认应用ID失败:", errorMessage);
+      set({ 
+        isLoadingAppId: false, 
+        errorLoadingAppId: errorMessage 
+      });
+    }
+  },
+  
+  // --- BEGIN COMMENT ---
+  // 新增刷新当前应用的方法，用于重新获取最新的应用实例信息
+  // --- END COMMENT ---
+  refreshCurrentApp: async () => {
+    const currentState = get();
+    
+    if (!currentState.currentAppInstance) {
+      // 如果没有当前应用，尝试初始化默认应用
+      await get().initializeDefaultAppId();
+      return;
+    }
+    
+    set({ isLoadingAppId: true, errorLoadingAppId: null });
+    
+    try {
+      const defaultInstanceResult = await getDefaultServiceInstance(
+        currentState.currentAppInstance.provider_id
+      );
+      
+      if (!defaultInstanceResult.success) {
+        throw new Error(`刷新应用实例失败: ${defaultInstanceResult.error.message}`);
+      }
+      
+      if (defaultInstanceResult.data && defaultInstanceResult.data.instance_id) {
+        set({
+          currentAppId: defaultInstanceResult.data.instance_id,
+          currentAppInstance: defaultInstanceResult.data,
+          isLoadingAppId: false,
+        });
+      } else {
+        const errorMessage = "未找到默认服务实例";
+        set({ 
+          isLoadingAppId: false, 
+          errorLoadingAppId: errorMessage 
+        });
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error("刷新当前应用失败:", errorMessage);
+      set({ 
+        isLoadingAppId: false, 
+        errorLoadingAppId: errorMessage 
+      });
+    }
+  },
+  
+  // --- BEGIN COMMENT ---
+  // 强制刷新默认应用，清除缓存并重新获取最新的默认应用
+  // --- END COMMENT ---
+  forceRefreshDefaultApp: async () => {
+    // 清除当前应用状态
+    set({
+      currentAppId: null,
+      currentAppInstance: null,
+      isLoadingAppId: false,
+      errorLoadingAppId: null,
+    });
+    
+    // 强制重新初始化
+    await get().initializeDefaultAppId(true);
+  },
+}));
 
 // --- BEGIN COMMENT ---
 // 使用建议:


### PR DESCRIPTION
问题：前端localStorage永久缓存应用ID，导致管理员更新配置后其他用户无法获取最新配置

解决：移除persist中间件，每次页面加载都从服务端获取最新的默认应用配置

效果：管理员配置完成后，所有用户下次访问立即使用最新配置，符合用户期望
