### PR TITLE
fix(auth): ensure service URL consistency in SSO callback validation

### DIFF
--- a/app/api/sso/[providerId]/callback/route.ts
+++ b/app/api/sso/[providerId]/callback/route.ts
@@ -56,8 +56,16 @@ export async function GET(
     const casService = await CASConfigService.createCASService(providerId);
     const casConfig = casService.getConfig();
 
-    // 验证ticket
-    const serviceUrl = `${appUrl}/api/sso/${providerId}/callback`;
+    // Validate ticket - ensure service URL matches exactly with login time
+    // Fix: Use the same logic as login time to build service URL
+    let serviceUrl = `${appUrl}/api/sso/${providerId}/callback`;
+    if (returnUrl) {
+      // If returnUrl parameter exists, add it to service URL
+      // This maintains consistency with login time service URL
+      serviceUrl = `${serviceUrl}?returnUrl=${encodeURIComponent(returnUrl)}`;
+    }
+    console.log(`Using service URL for ticket validation: ${serviceUrl}`);
+
     const validationResult = await casService.validateTicket(
       ticket,
       serviceUrl


### PR DESCRIPTION
Ensuring the serviceUrl used in CAS ticket validation matches the one used during login is essential for avoiding INVALID_SERVICE errors. Including returnUrl when present maintains consistency and improves compatibility with stricter CAS providers.

Consider adding validation for returnUrl to prevent potential open redirect issues.