### PR TITLE
fix(workflow): allow lockfile updates when upgrading dependencies

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -193,7 +193,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Run security audit
         run: |


### PR DESCRIPTION
Replace `--frozen-lockfile` with `--no-frozen-lockfile` to allow
pnpm-lock.yaml to be updated after running `ncu -u`.

This ensures that the lockfile stays in sync with the updated
package.json during dependency update workflows.
