### PR TITLE
feat(ui): add version display in about menu items

### DIFF
--- a/components/mobile/ui/user-bottom-sheet.tsx
+++ b/components/mobile/ui/user-bottom-sheet.tsx
@@ -41,6 +41,9 @@ export function UserBottomSheet({
   // Use useProfile hook to get user information
   const { profile } = useProfile();
 
+  // Get version from environment variable
+  const version = process.env.NEXT_PUBLIC_APP_VERSION;
+
   // Extract user information from profile
   const userName = profile?.full_name || profile?.username || t('defaultUser');
   const userRole =
@@ -75,7 +78,8 @@ export function UserBottomSheet({
     icon: React.ReactNode,
     label: string,
     onClick: () => void,
-    danger: boolean = false
+    danger: boolean = false,
+    showVersion: boolean = false
   ) => (
     <button
       onClick={onClick}
@@ -94,7 +98,18 @@ export function UserBottomSheet({
       )}
     >
       <span className="mr-3 flex-shrink-0">{icon}</span>
-      <span className="font-serif font-medium">{label}</span>
+      <span className="flex-1 font-serif font-medium">{label}</span>
+      {/* Show version number if requested */}
+      {showVersion && version && (
+        <span
+          className={cn(
+            'font-serif text-xs opacity-60',
+            isDark ? 'text-stone-400' : 'text-stone-500'
+          )}
+        >
+          v{version}
+        </span>
+      )}
     </button>
   );
 
@@ -166,7 +181,9 @@ export function UserBottomSheet({
               () => {
                 router.push('/about');
                 onClose();
-              }
+              },
+              false, // not a danger item
+              true // show version number
             )}
           </div>
 

--- a/components/nav-bar/desktop-user-avatar.tsx
+++ b/components/nav-bar/desktop-user-avatar.tsx
@@ -25,6 +25,9 @@ export function DesktopUserAvatar() {
   const t = useTranslations('navbar.user');
   const tRoles = useTranslations('pages.settings.profileSettings.roles');
 
+  // Get version from environment variable
+  const version = process.env.NEXT_PUBLIC_APP_VERSION;
+
   // Use useProfile hook to get user information, automatically handle cache and authentication status synchronization
   const { profile } = useProfile();
 
@@ -269,6 +272,17 @@ export function DesktopUserAvatar() {
                         >
                           {item.label}
                         </span>
+                        {/* Show version number for About menu item */}
+                        {item.label === t('about') && version && (
+                          <span
+                            className={cn(
+                              'font-serif text-xs opacity-60',
+                              isDark ? 'text-[#a8a29e]' : 'text-[#78716c]'
+                            )}
+                          >
+                            v{version}
+                          </span>
+                        )}
                       </button>
                     );
                   })}

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,8 @@ import withBundleAnalyzer from '@next/bundle-analyzer';
 import type { NextConfig } from 'next';
 import createNextIntlPlugin from 'next-intl/plugin';
 
+import pkg from './package.json';
+
 /**
  * Next.js Configuration
  * @description Configure Next.js with traditional webpack to avoid Turbopack font loading issues
@@ -19,6 +21,11 @@ const bundleAnalyzer = withBundleAnalyzer({
 
 const nextConfig: NextConfig = {
   /* config options here */
+
+  // Inject version information for frontend display
+  env: {
+    NEXT_PUBLIC_APP_VERSION: pkg.version,
+  },
 
   // Enable standalone output only when explicitly requested
   output:


### PR DESCRIPTION
Add application version number display next to 'About' menu items in both

mobile and desktop user interfaces. Version is extracted from package.json

and exposed via NEXT_PUBLIC_APP_VERSION environment variable.

Changes:

- Extract version from package.json in next.config.ts

- Display version number in mobile user bottom sheet about menu

- Display version number in desktop user avatar dropdown about menu

- Maintain consistent styling with existing theme colors

- Version appears as 'v{version}' with subtle opacity styling

> [!IMPORTANT]
>
> 1. Read [CONTRIBUTING.md](../CONTRIBUTING.md)
> 2. Ensure issue exists and you're assigned
> 3. Link correctly: `Fixes #<issue number>`

## What & Why

**What**: Brief description
**Why**: Problem solved

Fixes #(issue number)

## Pre-PR Checklist

Run these:

- [x] `pnpm type-check`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm i18n:check` (if applicable)

## Type

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 💥 Breaking change
- [ ] 📚 Docs
- [ ] ♻️ Refactor
- [ ] ⚡ Performance

## Screenshots (if UI changes)
