### PR TITLE
fix(ci): replace GITHUB_TOKEN with GH_PAT for PR creation

### DIFF
--- a/.github/workflows/auto-i18n-translation.yml
+++ b/.github/workflows/auto-i18n-translation.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -54,7 +54,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
           branch: auto-i18n-updates
           delete-branch: true
           title: "chore(i18n): auto-update translations"


### PR DESCRIPTION
## What & Why

**What**: Replace GITHUB_TOKEN with GH_PAT in auto-i18n-translation workflow
**Why**: Fix GitHub Actions permission error preventing automatic PR creation for i18n translations

Fixes the issue where auto-i18n-translation workflow fails with "GitHub Actions is not permitted to create or approve pull requests" error.

## Pre-PR Checklist

Run these:

- [x] `pnpm type-check`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm i18n:check` (if applicable)

## Type

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 💥 Breaking change
- [ ] 📚 Docs
- [ ] ♻️ Refactor
- [ ] ⚡ Performance

## Changes Made

1. **Checkout step**: Updated to use `GH_PAT` instead of `GITHUB_TOKEN`
2. **Create Pull Request step**: Updated to use `GH_PAT` instead of `GITHUB_TOKEN`

## Prerequisites

Before merging this PR, you need to:

1. Create a Personal Access Token (Classic) with `repo` permissions
2. Add it as a repository secret named `GH_PAT` in Settings > Secrets and variables > Actions

## Testing

After creating the PAT and secret, test by:
- Modifying `messages/en-US.json` to trigger the workflow
- Verify that the workflow successfully creates a PR