### PR TITLE
fix(i18n): replace hardcoded text with translation in file preview

### DIFF
--- a/components/file-preview/file-preview-canvas.tsx
+++ b/components/file-preview/file-preview-canvas.tsx
@@ -334,6 +334,7 @@ export const FilePreviewCanvas = () => {
     useFilePreviewStore();
   const { isDark } = useTheme();
   const pathname = usePathname();
+  const t = useTranslations('filePreview');
 
   // Auto-close preview when route changes (best practice for modal state management)
   useEffect(() => {
@@ -396,7 +397,7 @@ export const FilePreviewCanvas = () => {
                     ? 'text-stone-300 hover:bg-stone-700 hover:text-stone-200'
                     : 'text-stone-600 hover:bg-stone-200 hover:text-stone-800'
                 )}
-                aria-label="Close preview"
+                aria-label={t('closeButton')}
               >
                 <XIcon className="h-5 w-5" />
               </button>

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -2338,6 +2338,7 @@
     "retryButton": "Retry",
     "dismissButton": "Dismiss",
     "downloadButton": "Download File",
+    "closeButton": "Close preview",
     "noFileSelected": "No file selected",
     "previewNotSupported": "Preview not supported for this file type. You can download it to view the content.",
     "textPreview": {

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -2338,6 +2338,7 @@
     "retryButton": "重试",
     "dismissButton": "关闭",
     "downloadButton": "下载文件",
+    "closeButton": "关闭预览",
     "noFileSelected": "未选择文件",
     "previewNotSupported": "不支持预览此文件类型。您可以下载查看内容。",
     "textPreview": {


### PR DESCRIPTION
## What & Why

**What**: Replace hardcoded "Close preview" text with internationalized translation key
**Why**: Improve i18n coverage by eliminating hardcoded English text in file preview component

## Pre-PR Checklist

Run these:

- [x] `pnpm type-check`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm i18n:check` (if applicable)

## Type

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 💥 Breaking change
- [ ] 📚 Docs
- [ ] ♻️ Refactor
- [ ] ⚡ Performance

## Changes Made

1. **Translation Keys**: Added `filePreview.closeButton` key to `en-US.json` and `zh-CN.json`
2. **Component Fix**: Replaced hardcoded `aria-label="Close preview"` with `aria-label={t('closeButton')}`
3. **Hook Addition**: Added `useTranslations('filePreview')` hook to `FilePreviewCanvas` component

## Files Modified

- `messages/en-US.json` - Added English translation key
- `messages/zh-CN.json` - Added Chinese translation key  
- `components/file-preview/file-preview-canvas.tsx` - Replaced hardcoded text and added translation hook

## Testing

- [x] TypeScript compilation passes
- [x] ESLint and Prettier checks pass
- [x] Component maintains existing functionality
- [x] Translation key works correctly for accessibility