### PR TITLE
chore: lock pnpm version to 10.14.0

### DIFF
--- a/.github/workflows/auto-i18n-translation.yml
+++ b/.github/workflows/auto-i18n-translation.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: "9"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -16,8 +16,6 @@ jobs:
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
           
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ concurrency:
 
 env:
   NODE_VERSION: '18'
-  PNPM_VERSION: '9'
 
 jobs:
   # Check if files have changed to skip unnecessary jobs
@@ -83,8 +82,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -120,8 +117,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -162,8 +157,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -193,8 +186,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -234,8 +225,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -264,8 +253,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,8 +21,6 @@ jobs:
       
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: 9
         
     - name: Setup Node.js
       uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "agentifui",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.14.0",
   "scripts": {
     "dev": "cross-env NODE_OPTIONS='--inspect' next dev",
     "dev:clean": "next dev",


### PR DESCRIPTION
## What & Why

**What**: Add packageManager field to lock pnpm version at 10.14.0
**Why**: Ensure team uses consistent package manager version and avoid dependency resolution inconsistencies across development environments

## Pre-PR Checklist

Run these:

- [x] `pnpm type-check` ✅ Passed
- [x] `pnpm format:check` ✅ Passed via lint-staged
- [x] `pnpm lint` ✅ Passed via pre-commit hooks
- [x] `pnpm build` ✅ Not needed for config change
- [x] `pnpm i18n:check` ✅ Not applicable

## Type

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 💥 Breaking change
- [ ] 📚 Docs
- [x] ♻️ Refactor
- [ ] ⚡ Performance

## Details

- Added `"packageManager": "pnpm@10.14.0"` to package.json
- This ensures all team members and CI/CD use the same pnpm version
- Prevents inconsistencies in dependency resolution and lock file generation
- Enables Corepack auto-switching when available