### PR TITLE
refactor: replace isDark with dark: prefix in settings components

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,9 @@
 @import '../styles/markdown.css';
 @import '../styles/markdown-variables.css';
 
+/* Tailwind v4 dark mode configuration */
+@variant dark (&:where(.dark, .dark *));
+
 /* Add base style to prevent flicker */
 html {
   transition: background-color 0ms ease-out;

--- a/components/settings/account/account-settings.tsx
+++ b/components/settings/account/account-settings.tsx
@@ -2,7 +2,6 @@
 
 import { useLogout } from '@lib/hooks/use-logout';
 import { useSettingsColors } from '@lib/hooks/use-settings-colors';
-import { useTheme } from '@lib/hooks/use-theme';
 import { createClient } from '@lib/supabase/client';
 import { cn } from '@lib/utils';
 import { motion } from 'framer-motion';
@@ -17,7 +16,6 @@ import { useRouter } from 'next/navigation';
 // Includes all account-related logic: data loading, state management, logout, etc.
 export function AccountSettings() {
   const { colors } = useSettingsColors();
-  const { isDark } = useTheme();
   const { logout } = useLogout();
   const t = useTranslations('pages.settings.accountSettings');
   const tCommon = useTranslations('common.ui');
@@ -94,15 +92,13 @@ export function AccountSettings() {
         <div
           className={cn(
             'mb-6 rounded-lg p-6',
-            isDark
-              ? 'border border-red-800 bg-red-900/20 text-red-300'
-              : 'border border-red-200 bg-red-50 text-red-700'
+            'border border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300'
           )}
         >
           <h2
             className={cn(
               'mb-4 font-serif text-lg font-medium',
-              isDark ? 'text-red-200' : 'text-red-800'
+              'text-red-800 dark:text-red-200'
             )}
           >
             {t('loadAccountError')}
@@ -112,9 +108,7 @@ export function AccountSettings() {
             onClick={() => window.location.reload()}
             className={cn(
               'rounded-md px-4 py-2 font-serif transition-colors',
-              isDark
-                ? 'bg-red-800/50 text-red-200 hover:bg-red-700/50'
-                : 'bg-red-100 text-red-800 hover:bg-red-200'
+              'bg-red-100 text-red-800 hover:bg-red-200 dark:bg-red-800/50 dark:text-red-200 dark:hover:bg-red-700/50'
             )}
           >
             {t('retry')}
@@ -292,9 +286,7 @@ export function AccountSettings() {
                 animate={{ opacity: 1, y: 0 }}
                 className={cn(
                   'flex items-center rounded-lg border p-4',
-                  isDark
-                    ? 'border-red-800 bg-red-900/20 text-red-300'
-                    : 'border-red-200 bg-red-50 text-red-700'
+                  'border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300'
                 )}
               >
                 <AlertCircle className="mr-2 h-5 w-5 flex-shrink-0" />
@@ -343,9 +335,7 @@ export function AccountSettings() {
                     'cursor-pointer',
                     'font-serif text-sm',
                     showConfirm
-                      ? isDark
-                        ? 'bg-red-600 text-white hover:bg-red-700'
-                        : 'bg-red-600 text-white hover:bg-red-700'
+                      ? 'bg-red-600 text-white hover:bg-red-700'
                       : `${colors.primaryButtonBackground.tailwind} ${colors.primaryButtonHover.tailwind} ${colors.primaryButtonText.tailwind}`
                   )}
                 >

--- a/components/settings/appearance/language-card.tsx
+++ b/components/settings/appearance/language-card.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { SupportedLocale, getLanguageInfo } from '@lib/config/language-config';
-import { useTheme } from '@lib/hooks/use-theme';
 import { cn } from '@lib/utils';
 import { Check, Globe2 } from 'lucide-react';
 
@@ -19,7 +18,6 @@ export function LanguageCard({
   currentLanguage,
   onClick,
 }: LanguageCardProps) {
-  const { isDark } = useTheme();
   const isActive = currentLanguage === language;
   const languageInfo = getLanguageInfo(language);
 
@@ -31,13 +29,9 @@ export function LanguageCard({
         'hover:-translate-y-0.5 hover:shadow-lg',
         isActive
           ? // Selected state - stone style
-            isDark
-            ? 'border-stone-400 bg-stone-800/50 shadow-md ring-2 ring-stone-400/30'
-            : 'border-stone-600 bg-stone-50 shadow-md ring-2 ring-stone-600/20'
+            'border-stone-600 bg-stone-50 shadow-md ring-2 ring-stone-600/20 dark:border-stone-400 dark:bg-stone-800/50 dark:ring-stone-400/30'
           : // Unselected state
-            isDark
-            ? 'border-stone-700 bg-stone-900/30 hover:border-stone-600 hover:bg-stone-800/50'
-            : 'border-stone-200 bg-white hover:border-stone-300 hover:bg-stone-50'
+            'border-stone-200 bg-white hover:border-stone-300 hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-900/30 dark:hover:border-stone-600 dark:hover:bg-stone-800/50'
       )}
     >
       {/* Selected state indicator */}
@@ -46,7 +40,7 @@ export function LanguageCard({
           <div
             className={cn(
               'flex h-5 w-5 items-center justify-center rounded-full',
-              isDark ? 'bg-stone-400 text-stone-900' : 'bg-stone-600 text-white'
+              'bg-stone-600 text-white dark:bg-stone-400 dark:text-stone-900'
             )}
           >
             <Check className="h-3 w-3" />
@@ -61,12 +55,8 @@ export function LanguageCard({
           className={cn(
             'flex h-10 w-10 items-center justify-center rounded-lg',
             isActive
-              ? isDark
-                ? 'bg-stone-700 text-stone-300'
-                : 'bg-stone-200 text-stone-700'
-              : isDark
-                ? 'bg-stone-800 text-stone-400'
-                : 'bg-stone-100 text-stone-600'
+              ? 'bg-stone-200 text-stone-700 dark:bg-stone-700 dark:text-stone-300'
+              : 'bg-stone-100 text-stone-600 dark:bg-stone-800 dark:text-stone-400'
           )}
         >
           <Globe2 className="h-5 w-5" />
@@ -79,12 +69,8 @@ export function LanguageCard({
             className={cn(
               'font-serif text-base leading-tight font-semibold',
               isActive
-                ? isDark
-                  ? 'text-stone-100'
-                  : 'text-stone-900'
-                : isDark
-                  ? 'text-stone-200'
-                  : 'text-stone-800'
+                ? 'text-stone-900 dark:text-stone-100'
+                : 'text-stone-800 dark:text-stone-200'
             )}
           >
             {languageInfo.nativeName}
@@ -95,12 +81,8 @@ export function LanguageCard({
             className={cn(
               'mt-0.5 font-serif text-sm',
               isActive
-                ? isDark
-                  ? 'text-stone-300'
-                  : 'text-stone-600'
-                : isDark
-                  ? 'text-stone-400'
-                  : 'text-stone-500'
+                ? 'text-stone-600 dark:text-stone-300'
+                : 'text-stone-500 dark:text-stone-400'
             )}
           >
             {languageInfo.name}

--- a/components/settings/appearance/theme-card.tsx
+++ b/components/settings/appearance/theme-card.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useTheme } from '@lib/hooks/use-theme';
 import { cn } from '@lib/utils';
 import { ArrowUpIcon, Paperclip } from 'lucide-react';
 
@@ -20,7 +19,6 @@ export function ThemeCard({
   currentTheme,
   onClick,
 }: ThemeCardProps) {
-  const { isDark } = useTheme();
   const isActive = currentTheme === theme;
 
   // Get preview style configuration based on theme type
@@ -105,9 +103,7 @@ export function ThemeCard({
         isActive
           ? // Use deep blue selected state, thinner line
             'border-blue-800 shadow-md ring-1 ring-blue-800/20'
-          : isDark
-            ? 'border-stone-700 hover:border-stone-600'
-            : 'border-stone-200 hover:border-stone-300'
+          : 'border-stone-200 hover:border-stone-300 dark:border-stone-700 dark:hover:border-stone-600'
       )}
     >
       {/* Chat interface preview simulation */}
@@ -224,12 +220,8 @@ export function ThemeCard({
           className={cn(
             'text-center text-sm font-medium',
             isActive
-              ? isDark
-                ? 'text-stone-300'
-                : 'text-stone-700'
-              : isDark
-                ? 'text-stone-200'
-                : 'text-stone-900'
+              ? 'text-stone-700 dark:text-stone-300'
+              : 'text-stone-900 dark:text-stone-200'
           )}
         >
           {title}

--- a/components/settings/appearance/timezone-selector.tsx
+++ b/components/settings/appearance/timezone-selector.tsx
@@ -4,7 +4,6 @@ import {
   DateFormatPresets,
   useDateFormatter,
 } from '@lib/hooks/use-date-formatter';
-import { useTheme } from '@lib/hooks/use-theme';
 import { cn } from '@lib/utils';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Check, ChevronRight, MapPin, Timer, X } from 'lucide-react';
@@ -213,7 +212,6 @@ export function TimezoneSelector({
   className,
 }: TimezoneSelectorProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const { isDark } = useTheme();
   const t = useTranslations('pages.settings.appearanceSettings');
   const { formatDate } = useDateFormatter();
 
@@ -286,18 +284,16 @@ export function TimezoneSelector({
         className={cn(
           'flex w-full items-center justify-between rounded-xl border-2 p-4 transition-all duration-200',
           'group hover:-translate-y-0.5 hover:shadow-lg',
-          isDark
-            ? 'border-stone-700 bg-stone-800/60 hover:border-stone-600'
-            : 'border-stone-200 bg-white hover:border-stone-300'
+          'border-stone-200 bg-white hover:border-stone-300',
+          'dark:border-stone-700 dark:bg-stone-800/60 dark:hover:border-stone-600'
         )}
       >
         <div className="flex items-center space-x-3">
           <div
             className={cn(
               'flex h-10 w-10 items-center justify-center rounded-lg transition-colors duration-200',
-              isDark
-                ? 'bg-stone-700 text-stone-400'
-                : 'bg-stone-100 text-stone-600'
+              'bg-stone-100 text-stone-600',
+              'dark:bg-stone-700 dark:text-stone-400'
             )}
           >
             <Timer className="h-5 w-5" />
@@ -306,7 +302,7 @@ export function TimezoneSelector({
             <p
               className={cn(
                 'font-serif text-sm font-semibold',
-                isDark ? 'text-stone-200' : 'text-stone-800'
+                'text-stone-800 dark:text-stone-200'
               )}
             >
               {selectedTimezone
@@ -316,7 +312,7 @@ export function TimezoneSelector({
             <p
               className={cn(
                 'font-serif text-xs',
-                isDark ? 'text-stone-400' : 'text-stone-500'
+                'text-stone-500 dark:text-stone-400'
               )}
             >
               {currentTime}
@@ -326,7 +322,7 @@ export function TimezoneSelector({
         <ChevronRight
           className={cn(
             'h-5 w-5 transition-transform duration-200 group-hover:translate-x-1',
-            isDark ? 'text-stone-400' : 'text-stone-500'
+            'text-stone-500 dark:text-stone-400'
           )}
         />
       </button>
@@ -350,25 +346,23 @@ export function TimezoneSelector({
               onClick={e => e.stopPropagation()}
               className={cn(
                 'w-full max-w-lg overflow-hidden rounded-xl border shadow-2xl',
-                isDark
-                  ? 'border-stone-700 bg-stone-800'
-                  : 'border-stone-200 bg-white'
+                'border-stone-200 bg-white',
+                'dark:border-stone-700 dark:bg-stone-800'
               )}
             >
               {/* Modal header - simplified design */}
               <div
                 className={cn(
                   'flex items-center justify-between border-b px-6 py-4',
-                  isDark ? 'border-stone-700' : 'border-stone-200'
+                  'border-stone-200 dark:border-stone-700'
                 )}
               >
                 <div className="flex items-center space-x-3">
                   <div
                     className={cn(
                       'flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg',
-                      isDark
-                        ? 'bg-stone-700 text-stone-300'
-                        : 'bg-stone-100 text-stone-700'
+                      'bg-stone-100 text-stone-700',
+                      'dark:bg-stone-700 dark:text-stone-300'
                     )}
                   >
                     <MapPin className="h-5 w-5" />
@@ -377,7 +371,7 @@ export function TimezoneSelector({
                     <h2
                       className={cn(
                         'font-serif text-lg font-bold',
-                        isDark ? 'text-stone-100' : 'text-stone-900'
+                        'text-stone-900 dark:text-stone-100'
                       )}
                     >
                       {t('timezone')}
@@ -385,7 +379,7 @@ export function TimezoneSelector({
                     <p
                       className={cn(
                         'font-serif text-sm',
-                        isDark ? 'text-stone-400' : 'text-stone-600'
+                        'text-stone-600 dark:text-stone-400'
                       )}
                     >
                       {t('timezoneDescription')}
@@ -397,9 +391,8 @@ export function TimezoneSelector({
                   onClick={() => setIsModalOpen(false)}
                   className={cn(
                     'rounded-lg p-2 transition-colors duration-200',
-                    isDark
-                      ? 'text-stone-400 hover:bg-stone-700 hover:text-stone-300'
-                      : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                    'text-gray-600 hover:bg-gray-100 hover:text-gray-900',
+                    'dark:text-stone-400 dark:hover:bg-stone-700 dark:hover:text-stone-300'
                   )}
                 >
                   <X className="h-5 w-5" />
@@ -416,28 +409,22 @@ export function TimezoneSelector({
                         'sticky top-0 z-20',
                         // Glass effect
                         'backdrop-blur-xl backdrop-saturate-150',
-                        // Gradient background - dark mode
-                        isDark
-                          ? [
-                              'via-stone-750/95 bg-gradient-to-r from-stone-800/90 to-stone-800/90',
-                              'border-b border-stone-700/60',
-                              'shadow-lg shadow-stone-900/40',
-                            ]
-                          : [
-                              // Light mode
-                              'bg-gradient-to-r from-stone-50/90 via-white/95 to-stone-50/90',
-                              'border-b border-stone-200/60',
-                              'shadow-lg shadow-stone-300/20',
-                            ]
+                        // Light mode gradient
+                        'bg-gradient-to-r from-stone-50/90 via-white/95 to-stone-50/90',
+                        'border-b border-stone-200/60',
+                        'shadow-lg shadow-stone-300/20',
+                        // Dark mode gradient
+                        'dark:via-stone-750/95 dark:from-stone-800/90 dark:to-stone-800/90',
+                        'dark:border-stone-700/60',
+                        'dark:shadow-stone-900/40'
                       )}
                     >
                       {/* Decorative top border */}
                       <div
                         className={cn(
                           'absolute inset-x-0 top-0 h-px',
-                          isDark
-                            ? 'bg-gradient-to-r from-transparent via-stone-500/50 to-transparent'
-                            : 'bg-gradient-to-r from-transparent via-stone-400/40 to-transparent'
+                          'bg-gradient-to-r from-transparent via-stone-400/40 to-transparent',
+                          'dark:via-stone-500/50'
                         )}
                       />
 
@@ -448,13 +435,13 @@ export function TimezoneSelector({
                             <div
                               className={cn(
                                 'h-2 w-2 rounded-full',
-                                isDark ? 'bg-stone-400' : 'bg-stone-600'
+                                'bg-stone-600 dark:bg-stone-400'
                               )}
                             />
                             <div
                               className={cn(
                                 'absolute inset-0 h-2 w-2 animate-pulse rounded-full',
-                                isDark ? 'bg-stone-400/30' : 'bg-stone-600/30'
+                                'bg-stone-600/30 dark:bg-stone-400/30'
                               )}
                             />
                           </div>
@@ -463,9 +450,8 @@ export function TimezoneSelector({
                             className={cn(
                               'font-serif text-sm font-bold tracking-wider uppercase',
                               'bg-gradient-to-r bg-clip-text text-transparent',
-                              isDark
-                                ? 'from-stone-100 to-stone-300'
-                                : 'from-stone-700 to-stone-900'
+                              'from-stone-700 to-stone-900',
+                              'dark:from-stone-100 dark:to-stone-300'
                             )}
                           >
                             {t(`timezoneRegions.${region}`)}
@@ -480,9 +466,8 @@ export function TimezoneSelector({
                       <div
                         className={cn(
                           'absolute inset-x-0 bottom-0 h-px',
-                          isDark
-                            ? 'bg-gradient-to-r from-transparent via-stone-600/30 to-transparent'
-                            : 'bg-gradient-to-r from-transparent via-stone-300/40 to-transparent'
+                          'bg-gradient-to-r from-transparent via-stone-300/40 to-transparent',
+                          'dark:via-stone-600/30'
                         )}
                       />
                     </div>
@@ -492,9 +477,8 @@ export function TimezoneSelector({
                       className={cn(
                         'relative space-y-2 p-4',
                         // Subtle background gradient
-                        isDark
-                          ? 'bg-gradient-to-b from-transparent to-stone-800/20'
-                          : 'bg-gradient-to-b from-transparent to-stone-50/30'
+                        'bg-gradient-to-b from-transparent to-stone-50/30',
+                        'dark:to-stone-800/20'
                       )}
                     >
                       {timezones.map(timezone => {
@@ -511,21 +495,16 @@ export function TimezoneSelector({
                               'flex w-full items-center justify-between rounded-lg p-3 transition-all duration-200',
                               'group relative overflow-hidden border hover:shadow-lg',
                               isSelected
-                                ? isDark
-                                  ? 'border-stone-500 bg-stone-600/60 shadow-md ring-1 ring-stone-500/30'
-                                  : 'border-stone-400 bg-stone-100/80 shadow-md ring-1 ring-stone-400/30'
-                                : isDark
-                                  ? 'hover:bg-stone-750/30 border-stone-700 hover:border-stone-600'
-                                  : 'border-stone-200 hover:border-stone-300 hover:bg-stone-50/50'
+                                ? 'border-stone-400 bg-stone-100/80 shadow-md ring-1 ring-stone-400/30 dark:border-stone-500 dark:bg-stone-600/60 dark:ring-stone-500/30'
+                                : 'dark:hover:bg-stone-750/30 border-stone-200 hover:border-stone-300 hover:bg-stone-50/50 dark:border-stone-700 dark:hover:border-stone-600'
                             )}
                           >
                             {/* Subtle hover gradient effect */}
                             <div
                               className={cn(
                                 'absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100',
-                                isDark
-                                  ? 'bg-gradient-to-r from-stone-700/20 to-stone-600/10'
-                                  : 'bg-gradient-to-r from-stone-100/40 to-stone-200/20'
+                                'bg-gradient-to-r from-stone-100/40 to-stone-200/20',
+                                'dark:from-stone-700/20 dark:to-stone-600/10'
                               )}
                             />
 
@@ -535,12 +514,8 @@ export function TimezoneSelector({
                                   className={cn(
                                     'font-serif text-sm font-semibold',
                                     isSelected
-                                      ? isDark
-                                        ? 'text-stone-100'
-                                        : 'text-stone-900'
-                                      : isDark
-                                        ? 'text-stone-200'
-                                        : 'text-stone-800'
+                                      ? 'text-stone-900 dark:text-stone-100'
+                                      : 'text-stone-800 dark:text-stone-200'
                                   )}
                                 >
                                   {cityName}
@@ -549,12 +524,8 @@ export function TimezoneSelector({
                                   className={cn(
                                     'mt-0.5 flex items-center space-x-1 font-serif text-xs',
                                     isSelected
-                                      ? isDark
-                                        ? 'text-stone-300'
-                                        : 'text-stone-600'
-                                      : isDark
-                                        ? 'text-stone-400'
-                                        : 'text-stone-500'
+                                      ? 'text-stone-600 dark:text-stone-300'
+                                      : 'text-stone-500 dark:text-stone-400'
                                   )}
                                 >
                                   <span className="font-medium">
@@ -572,9 +543,8 @@ export function TimezoneSelector({
                                   className={cn(
                                     'flex h-6 w-6 items-center justify-center rounded-full',
                                     'bg-gradient-to-r shadow-sm',
-                                    isDark
-                                      ? 'from-stone-500 to-stone-600 text-white shadow-stone-900/50'
-                                      : 'from-stone-600 to-stone-700 text-white shadow-stone-300/30'
+                                    'from-stone-600 to-stone-700 text-white shadow-stone-300/30',
+                                    'dark:from-stone-500 dark:to-stone-600 dark:shadow-stone-900/50'
                                   )}
                                 >
                                   <Check className="h-3 w-3" />

--- a/components/settings/profile/profile-settings.tsx
+++ b/components/settings/profile/profile-settings.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useProfile } from '@lib/hooks/use-profile';
+import { Profile as ExtendedProfile, useProfile } from '@lib/hooks/use-profile';
 import { useSettingsColors } from '@lib/hooks/use-settings-colors';
-import { useTheme } from '@lib/hooks/use-theme';
+import { Profile as DatabaseProfile } from '@lib/types/database';
 import { cn } from '@lib/utils';
 import { motion } from 'framer-motion';
 
@@ -14,7 +14,6 @@ import { ProfileForm } from './profile-form';
 // Contains all data loading, state management, and UI logic
 export function ProfileSettings() {
   const { colors } = useSettingsColors();
-  const { isDark } = useTheme();
   const t = useTranslations('pages.settings.profileSettings');
   const tCommon = useTranslations('common.ui');
 
@@ -40,15 +39,13 @@ export function ProfileSettings() {
         <div
           className={cn(
             'mb-6 rounded-lg p-6',
-            isDark
-              ? 'border border-red-800 bg-red-900/20 text-red-300'
-              : 'border border-red-200 bg-red-50 text-red-700'
+            'border border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300'
           )}
         >
           <h2
             className={cn(
               'mb-4 font-serif text-lg font-medium',
-              isDark ? 'text-red-200' : 'text-red-800'
+              'text-red-800 dark:text-red-200'
             )}
           >
             {t('loadProfileError')}
@@ -58,9 +55,7 @@ export function ProfileSettings() {
             onClick={() => window.location.reload()}
             className={cn(
               'rounded-md px-4 py-2 font-serif transition-colors',
-              isDark
-                ? 'bg-red-800/50 text-red-200 hover:bg-red-700/50'
-                : 'bg-red-100 text-red-800 hover:bg-red-200'
+              'bg-red-100 text-red-800 hover:bg-red-200 dark:bg-red-800/50 dark:text-red-200 dark:hover:bg-red-700/50'
             )}
           >
             {tCommon('retry')}
@@ -237,7 +232,10 @@ export function ProfileSettings() {
 
       {profile && (
         <ProfileForm
-          profile={profile as any}
+          profile={
+            profile as DatabaseProfile &
+              ExtendedProfile & { auth_last_sign_in_at?: string }
+          }
           onSuccess={handleProfileUpdateSuccess}
         />
       )}


### PR DESCRIPTION
## Summary
Replace runtime `isDark` conditional logic with Tailwind's static `dark:` prefix classes in settings components for better performance and maintainability.

## Changes
- Fixed Tailwind v4 dark mode configuration in `globals.css`
- Refactored settings appearance components (timezone-selector, language-card, theme-card)
- Fixed TypeScript type safety in ProfileSettings component
- Removed runtime theme checks in favor of static CSS classes

## Technical Details
- Added `@variant dark (&:where(.dark, .dark *));` to enable dark: prefix
- Converted conditional styling from `isDark ? 'dark' : 'light'` to `'light dark:dark'`
- Improved type safety by replacing `any` with proper intersection types
- Performance improvement through elimination of runtime theme checks

## Testing
- Theme switching works correctly across all refactored components  
- Static CSS classes enable better tree-shaking optimization
- Type safety verified with proper DatabaseProfile & ExtendedProfile types

## Related
Supersedes #221 - This PR contains actual implementation while #221 is still WIP
Fixes #220