### PR TITLE
fix(ui): correct color mapping in sidebar and chat-input components

### DIFF
--- a/components/chat-input/button.tsx
+++ b/components/chat-input/button.tsx
@@ -41,7 +41,7 @@ export const ChatButton = ({
         disabled={disabled}
         className={cn(
           'flex h-8 w-8 items-center justify-center rounded-lg',
-          'border border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-stone-600 dark:bg-stone-600/30 dark:text-stone-300 dark:hover:bg-stone-700/50',
+          'border border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-stone-600 dark:bg-stone-600/30 dark:text-gray-100 dark:hover:bg-stone-600',
           'bg-transparent',
           'cursor-pointer',
           className
@@ -63,7 +63,7 @@ export const ChatButton = ({
         'flex h-8 w-8 items-center justify-center rounded-full',
         forceActiveStyle || !disabled
           ? 'bg-black text-white hover:bg-gray-800 dark:bg-stone-900 dark:hover:bg-stone-800'
-          : 'bg-gray-200 text-gray-400 dark:bg-stone-600 dark:text-stone-300',
+          : 'bg-gray-200 text-gray-400 dark:bg-stone-600 dark:text-gray-100',
         'cursor-pointer shadow-sm',
         className
       )}

--- a/components/chat-input/container.tsx
+++ b/components/chat-input/container.tsx
@@ -62,7 +62,7 @@ export const ChatContainer = ({
       <div
         className={cn(
           'flex flex-col rounded-2xl',
-          'bg-white dark:bg-stone-800',
+          'bg-white dark:bg-stone-700',
           'shadow-[0_0_15px_rgba(0,0,0,0.1)]'
         )}
       >

--- a/components/sidebar/sidebar-container.tsx
+++ b/components/sidebar/sidebar-container.tsx
@@ -83,14 +83,14 @@ export function SidebarContainer() {
         isMobile ? 'z-50' : 'z-30',
 
         isExpanded
-          ? 'bg-stone-100/80 dark:bg-stone-800/80'
-          : 'bg-stone-50/80 dark:bg-stone-900/80',
+          ? 'bg-stone-200 dark:bg-stone-700'
+          : 'bg-stone-100 dark:bg-stone-800',
         'backdrop-blur-sm',
         'border-r-stone-300/60 dark:border-r-stone-700/50',
         'text-stone-700 dark:text-stone-300',
         !isExpanded &&
           !isMobile &&
-          'hover:bg-stone-200 dark:hover:bg-stone-700',
+          'hover:bg-stone-300 dark:hover:bg-stone-600',
         'select-none',
         (!isExpanded && !isMobile) || (isAnimating && !isMobile)
           ? 'cursor-e-resize'

--- a/components/sidebar/sidebar-container.tsx
+++ b/components/sidebar/sidebar-container.tsx
@@ -85,7 +85,6 @@ export function SidebarContainer() {
         isExpanded
           ? 'bg-stone-200 dark:bg-stone-700'
           : 'bg-stone-100 dark:bg-stone-800',
-        'backdrop-blur-sm',
         'border-r-stone-300/60 dark:border-r-stone-700/50',
         'text-stone-700 dark:text-stone-300',
         !isExpanded &&


### PR DESCRIPTION
## What & Why

**What**: Fixed incorrect color mapping in sidebar and chat-input components
**Why**: Color definitions didn't match main-colors.ts design system, causing visual inconsistencies

Related to #220

## Pre-PR Checklist

- [x] `pnpm type-check`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm i18n:check` (if applicable)

## Type

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 💥 Breaking change
- [ ] 📚 Docs
- [ ] ♻️ Refactor
- [ ] ⚡ Performance

## Changes

### Fixed Color Mappings

**Sidebar Container (`components/sidebar/sidebar-container.tsx`)**:
- Expanded state: `bg-stone-100/80 dark:bg-stone-800/80` → `bg-stone-200 dark:bg-stone-700`
- Collapsed state: `bg-stone-50/80 dark:bg-stone-900/80` → `bg-stone-100 dark:bg-stone-800`
- Hover effect: `hover:bg-stone-200 dark:hover:bg-stone-700` → `hover:bg-stone-300 dark:hover:bg-stone-600`

**Chat Input Components**:
- Container background: `dark:bg-stone-800` → `dark:bg-stone-700` (sidebarBackground)
- Button text: `dark:text-stone-300` → `dark:text-gray-100` (mainText)
- Button hover: `dark:hover:bg-stone-700/50` → `dark:hover:bg-stone-600` (buttonHover)

All colors now correctly match the design system defined in `lib/theme/main-colors.ts`.