### PR TITLE
fix(sidebar): match expanded background color with hover state

### DIFF
--- a/components/sidebar/sidebar-container.tsx
+++ b/components/sidebar/sidebar-container.tsx
@@ -83,7 +83,7 @@ export function SidebarContainer() {
         isMobile ? 'z-50' : 'z-30',
 
         isExpanded
-          ? 'bg-stone-100/80 dark:bg-stone-800/80'
+          ? 'bg-stone-200 dark:bg-stone-700'
           : 'bg-stone-50/80 dark:bg-stone-900/80',
         'backdrop-blur-sm',
         'border-r-stone-300/60 dark:border-r-stone-700/50',


### PR DESCRIPTION
## What & Why

**What**: Update sidebar container background color to match hover state when expanded
**Why**: Improve visual consistency by making expanded state use the same background color as hover state

## Pre-PR Checklist

Run these:

- [x] `pnpm type-check`
- [x] `pnpm format:check` 
- [x] `pnpm lint` (existing lint issues unrelated to changes)
- [x] `pnpm build`
- [x] `pnpm i18n:check` (not applicable)

## Type

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 💥 Breaking change
- [ ] 📚 Docs
- [ ] ♻️ Refactor
- [ ] ⚡ Performance

## Changes

- Updated sidebar container expanded background color from `bg-stone-100/80` to `bg-stone-200` (light mode)
- Updated sidebar container expanded background color from `dark:bg-stone-800/80` to `dark:bg-stone-700` (dark mode)
- Now matches the existing hover state colors for better visual consistency

## Screenshots (if UI changes)

This is a subtle color change that improves visual consistency when the sidebar is expanded.