### PR TITLE
fix(i18n): fix Start Exploring button navigation URL in all languages

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -2113,7 +2113,7 @@
                   "text": "Entdeckung beginnen",
                   "variant": "solid",
                   "action": "link",
-                  "url": "#",
+                  "url": "/chat",
                   "textAlign": "center"
                 }
               }

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -2113,7 +2113,7 @@
                   "text": "Start Exploring",
                   "variant": "solid",
                   "action": "link",
-                  "url": "#",
+                  "url": "/chat",
                   "textAlign": "center"
                 }
               }

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -2113,7 +2113,7 @@
                   "text": "Comenzar a Explorar",
                   "variant": "solid",
                   "action": "link",
-                  "url": "#",
+                  "url": "/chat",
                   "textAlign": "center"
                 }
               }

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -2113,7 +2113,7 @@
                   "text": "Commencer à explorer",
                   "variant": "solid",
                   "action": "link",
-                  "url": "#",
+                  "url": "/chat",
                   "textAlign": "center"
                 }
               }

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -2113,7 +2113,7 @@
                   "text": "Inizia a Esplorare",
                   "variant": "solid",
                   "action": "link",
-                  "url": "#",
+                  "url": "/chat",
                   "textAlign": "center"
                 }
               }

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -2113,7 +2113,7 @@
                   "text": "探索を始める",
                   "variant": "solid",
                   "action": "link",
-                  "url": "#",
+                  "url": "/chat",
                   "textAlign": "center"
                 }
               }

--- a/messages/pt-PT.json
+++ b/messages/pt-PT.json
@@ -2113,7 +2113,7 @@
                   "text": "Começar a Explorar",
                   "variant": "solid",
                   "action": "link",
-                  "url": "#",
+                  "url": "/chat",
                   "textAlign": "center"
                 }
               }

--- a/messages/ru-RU.json
+++ b/messages/ru-RU.json
@@ -2113,7 +2113,7 @@
                   "text": "Начать исследование",
                   "variant": "solid",
                   "action": "link",
-                  "url": "#",
+                  "url": "/chat",
                   "textAlign": "center"
                 }
               }

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -2113,7 +2113,7 @@
                   "text": "开始探索",
                   "variant": "solid",
                   "action": "link",
-                  "url": "#",
+                  "url": "/chat",
                   "textAlign": "center"
                 }
               }

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -2113,7 +2113,7 @@
                   "text": "開始探索",
                   "variant": "solid",
                   "action": "link",
-                  "url": "#",
+                  "url": "/chat",
                   "textAlign": "center"
                 }
               }


### PR DESCRIPTION
## What & Why

**What**: Fix Start Exploring button navigation on about page across all languages
**Why**: Button was configured with placeholder URL "#" preventing navigation, causing poor user experience

Fixes #245

## Pre-PR Checklist

Run these:

- [x] `pnpm type-check`
- [ ] `pnpm format:check`
- [ ] `pnpm lint`
- [ ] `pnpm build`
- [x] `pnpm i18n:check` (if applicable)

## Type

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 💥 Breaking change
- [ ] 📚 Docs
- [ ] ♻️ Refactor
- [ ] ⚡ Performance

## Technical Details

The "Start Exploring" button on the about page was configured with a placeholder URL `"#"` in all language files. The `ComponentRenderer`'s `DynamicButton` component prevents default navigation when URL is "#", causing the button to be non-functional.

**Root Cause**: Admin content configuration had placeholder URLs in default about page presets.

**Solution**: Updated all 10 language files to use `/chat` URL, matching the main page "Get Started" button behavior.

**Files Changed**:
- `messages/en-US.json` - "Start Exploring"
- `messages/de-DE.json` - "Entdeckung beginnen" 
- `messages/es-ES.json` - "Comenzar a Explorar"
- `messages/fr-FR.json` - "Commencer à explorer"
- `messages/it-IT.json` - "Inizia a Esplorare"
- `messages/ja-JP.json` - "探索を始める"
- `messages/pt-PT.json` - "Começar a Explorar"
- `messages/ru-RU.json` - "Начать исследование"
- `messages/zh-CN.json` - "开始探索"
- `messages/zh-TW.json` - "開始探索"

**Impact**: All language versions of the about page now have functional navigation, improving user onboarding flow.