### PR TITLE
fix(ui): prevent confirm dialog from blocking background modal intera…

### DIFF
--- a/components/ui/confirm-dialog.tsx
+++ b/components/ui/confirm-dialog.tsx
@@ -69,44 +69,25 @@ export function ConfirmDialog({
     if (!isOpen) return;
 
     const handleClickOutside = (e: MouseEvent) => {
-      // Stop all mouse events from propagating to prevent interaction with background modal
-      e.stopPropagation();
-
+      // Check if click is outside the dialog
       if (
         dialogRef.current &&
         !dialogRef.current.contains(e.target as Node) &&
         !isLoading
       ) {
+        e.stopPropagation();
         onClose();
       }
-    };
-
-    // Prevent all interactions with background elements
-    const preventBackgroundInteraction = (e: MouseEvent | TouchEvent) => {
-      e.stopPropagation();
-      e.preventDefault();
     };
 
     // Add delay to avoid closing immediately when opened
     const timer = setTimeout(() => {
       document.addEventListener('mousedown', handleClickOutside);
-      document.addEventListener('click', preventBackgroundInteraction, true);
-      document.addEventListener(
-        'touchstart',
-        preventBackgroundInteraction,
-        true
-      );
     }, 100);
 
     return () => {
       clearTimeout(timer);
       document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('click', preventBackgroundInteraction, true);
-      document.removeEventListener(
-        'touchstart',
-        preventBackgroundInteraction,
-        true
-      );
     };
   }, [isOpen, onClose, isLoading]);
 


### PR DESCRIPTION
## What & Why

**What**: Fixed confirm dialog preventing interactions with background modals
**Why**: The confirm dialog was overly aggressive in preventing event propagation, blocking all interactions with background modals even when they should remain accessible

Fixes #(to be assigned)

## Pre-PR Checklist

Run these:

- [x] `pnpm type-check`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm build`
- [ ] `pnpm i18n:check` (if applicable)

## Type

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 💥 Breaking change
- [ ] 📚 Docs
- [ ] ♻️ Refactor
- [ ] ⚡ Performance

## Screenshots (if UI changes)

N/A - This is a behavioral fix that allows background modals to remain interactive when the confirm dialog is open. The visual appearance remains unchanged.