### PR TITLE
fix(settings): remove invalid Beijing timezone and fix validation feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ docs/security
 
 # pm2
 pm2-logs/
+
+.serena

--- a/app/settings/appearance/page.tsx
+++ b/app/settings/appearance/page.tsx
@@ -6,6 +6,7 @@ import { useSettingsColors } from '@lib/hooks/use-settings-colors';
 import { useTheme } from '@lib/hooks/use-theme';
 import { useUserTimezone } from '@lib/hooks/use-user-timezone';
 import { motion } from 'framer-motion';
+import { toast } from 'sonner';
 
 import { useState } from 'react';
 
@@ -45,6 +46,12 @@ export default function AppearanceSettingsPage() {
 
     if (success) {
       console.log(`[AppearanceSettings] Timezone updated to: ${newTimezone}`);
+      toast.success(t('timezoneUpdated'));
+    } else {
+      console.error(
+        `[AppearanceSettings] Failed to update timezone to: ${newTimezone}`
+      );
+      toast.error(t('timezoneUpdateFailed'));
     }
 
     // Simulate save delay

--- a/components/settings/appearance/timezone-selector.tsx
+++ b/components/settings/appearance/timezone-selector.tsx
@@ -7,7 +7,6 @@ import {
 import { cn } from '@lib/utils';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Check, ChevronRight, MapPin, Timer, X } from 'lucide-react';
-import { toast } from 'sonner';
 
 import { useMemo, useState } from 'react';
 
@@ -38,12 +37,6 @@ const ALL_TIMEZONES: TimezoneOption[] = [
   {
     value: 'Asia/Shanghai',
     cityKey: 'shanghai',
-    region: 'asia',
-    offset: '+08:00',
-  },
-  {
-    value: 'Asia/Beijing',
-    cityKey: 'beijing',
     region: 'asia',
     offset: '+08:00',
   },
@@ -268,12 +261,6 @@ export function TimezoneSelector({
   const handleTimezoneSelect = (timezone: string) => {
     onChange(timezone);
     setIsModalOpen(false);
-
-    // Show success prompt
-    const selectedTz = ALL_TIMEZONES.find(tz => tz.value === timezone);
-    if (selectedTz) {
-      toast.success(t('timezoneUpdated'));
-    }
   };
 
   return (

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -967,7 +967,8 @@
         "systemTimezone": "System-Zeitzone",
         "customTimezone": "Benutzerdefinierte Zeitzone",
         "timezonePreview": "Vorschauzeit: {time}",
-        "timezoneUpdated": "Zeitzoneneinstellungen aktualisiert"
+        "timezoneUpdated": "Zeitzoneneinstellungen aktualisiert",
+        "timezoneUpdateFailed": "Zeitzone konnte nicht aktualisiert werden"
       },
       "languageSettings": {
         "title": "Spracheinstellungen",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -967,7 +967,8 @@
         "systemTimezone": "System Timezone",
         "customTimezone": "Custom Timezone",
         "timezonePreview": "Preview time: {time}",
-        "timezoneUpdated": "Timezone settings updated"
+        "timezoneUpdated": "Timezone settings updated",
+        "timezoneUpdateFailed": "Failed to update timezone"
       },
       "languageSettings": {
         "title": "Language Settings",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -967,7 +967,8 @@
         "systemTimezone": "Zona Horaria del Sistema",
         "customTimezone": "Zona Horaria Personalizada",
         "timezonePreview": "Hora de vista previa: {time}",
-        "timezoneUpdated": "Configuración de zona horaria actualizada"
+        "timezoneUpdated": "Configuración de zona horaria actualizada",
+        "timezoneUpdateFailed": "Error al actualizar la zona horaria"
       },
       "languageSettings": {
         "title": "Configuración de Idioma",

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -967,7 +967,8 @@
         "systemTimezone": "Fuseau horaire du système",
         "customTimezone": "Fuseau horaire personnalisé",
         "timezonePreview": "Aperçu de l'heure : {time}",
-        "timezoneUpdated": "Paramètres de fuseau horaire mis à jour"
+        "timezoneUpdated": "Paramètres de fuseau horaire mis à jour",
+        "timezoneUpdateFailed": "Échec de la mise à jour du fuseau horaire"
       },
       "languageSettings": {
         "title": "Paramètres de langue",

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -967,7 +967,8 @@
         "systemTimezone": "Fuso Orario di Sistema",
         "customTimezone": "Fuso Orario Personalizzato",
         "timezonePreview": "Ora di anteprima: {time}",
-        "timezoneUpdated": "Impostazioni del fuso orario aggiornate"
+        "timezoneUpdated": "Impostazioni del fuso orario aggiornate",
+        "timezoneUpdateFailed": "Impossibile aggiornare il fuso orario"
       },
       "languageSettings": {
         "title": "Impostazioni Lingua",

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -967,7 +967,8 @@
         "systemTimezone": "システムタイムゾーン",
         "customTimezone": "カスタムタイムゾーン",
         "timezonePreview": "プレビュー時刻：{time}",
-        "timezoneUpdated": "タイムゾーン設定が更新されました"
+        "timezoneUpdated": "タイムゾーン設定が更新されました",
+        "timezoneUpdateFailed": "タイムゾーンの更新に失敗しました"
       },
       "languageSettings": {
         "title": "言語設定",

--- a/messages/pt-PT.json
+++ b/messages/pt-PT.json
@@ -967,7 +967,8 @@
         "systemTimezone": "Fuso Horário do Sistema",
         "customTimezone": "Fuso Horário Personalizado",
         "timezonePreview": "Hora de pré-visualização: {time}",
-        "timezoneUpdated": "Definições de fuso horário atualizadas"
+        "timezoneUpdated": "Definições de fuso horário atualizadas",
+        "timezoneUpdateFailed": "Falha ao atualizar o fuso horário"
       },
       "languageSettings": {
         "title": "Definições de Idioma",

--- a/messages/ru-RU.json
+++ b/messages/ru-RU.json
@@ -967,7 +967,8 @@
         "systemTimezone": "Системный часовой пояс",
         "customTimezone": "Пользовательский часовой пояс",
         "timezonePreview": "Время предпросмотра: {time}",
-        "timezoneUpdated": "Настройки часового пояса обновлены"
+        "timezoneUpdated": "Настройки часового пояса обновлены",
+        "timezoneUpdateFailed": "Не удалось обновить часовой пояс"
       },
       "languageSettings": {
         "title": "Настройки языка",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -967,7 +967,8 @@
         "systemTimezone": "系统时区",
         "customTimezone": "自定义时区",
         "timezonePreview": "预览时间：{time}",
-        "timezoneUpdated": "时区设置已更新"
+        "timezoneUpdated": "时区设置已更新",
+        "timezoneUpdateFailed": "时区更新失败"
       },
       "languageSettings": {
         "title": "语言设置",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -967,7 +967,8 @@
         "systemTimezone": "系統時區",
         "customTimezone": "自定義時區",
         "timezonePreview": "預覽時間：{time}",
-        "timezoneUpdated": "時區設定已更新"
+        "timezoneUpdated": "時區設定已更新",
+        "timezoneUpdateFailed": "時區更新失敗"
       },
       "languageSettings": {
         "title": "語言設定",


### PR DESCRIPTION
## What & Why

**What**: Remove invalid 'Asia/Beijing' timezone entry and fix validation feedback logic
**Why**: Beijing timezone selection was failing silently with misleading success toast

Fixes #(no issue number - direct bug fix)

## Pre-PR Checklist

Run these:

- [x] `pnpm type-check`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm i18n:check` (if applicable)

## Type

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 💥 Breaking change
- [ ] 📚 Docs
- [ ] ♻️ Refactor
- [ ] ⚡ Performance

## Screenshots (if UI changes)

N/A - Backend validation logic fix, no visual UI changes

## Details

### Root Cause
- 'Asia/Beijing' is not a valid IANA timezone identifier (China uses 'Asia/Shanghai' for all mainland China)
- Success toast was shown before validation, creating false positive UX

### Changes Made
1. Removed invalid 'Asia/Beijing' entry from timezone list
2. Moved toast logic from TimezoneSelector component to parent page
3. Added proper success/error handling based on validation result
4. Added 'timezoneUpdateFailed' translation key to all 10 language files

### Testing
- TypeScript validation: ✅ Pass
- i18n consistency: ✅ All languages synchronized
- Build verification: ✅ Successful
- Lint checks: ✅ Clean