### PR TITLE
feat(notification): add types and constants foundation

### DIFF
--- a/lib/constants/notification-admin.ts
+++ b/lib/constants/notification-admin.ts
@@ -1,0 +1,32 @@
+/**
+ * Static variables for notification content insertion
+ */
+export const NOTIFICATION_VARIABLES = [
+  'username',
+  'time',
+  'date',
+  'agentName',
+  'duration',
+  'result',
+  'percentage',
+  'currentUsage',
+  'limit',
+  'details',
+  'ip',
+  'featureName',
+  'features',
+] as const;
+
+/**
+ * Default form values for creating notifications
+ */
+export const DEFAULT_NOTIFICATION_FORM = {
+  type: 'message' as const,
+  category: 'admin_announcement' as const,
+  title: '',
+  content: '',
+  priority: 'medium' as const,
+  target_roles: ['user'],
+  target_users: [],
+  scheduled_time: '',
+};

--- a/lib/templates/types.ts
+++ b/lib/templates/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Notification Template Type Definitions
+ *
+ * Core interfaces and types for the notification template system
+ */
+import type { NotificationCategory } from '@lib/types/notification-center';
+
+export interface NotificationTemplate {
+  /** Template identifier */
+  id: string;
+  /** Template name */
+  name: string;
+  /** Template description */
+  description: string;
+  /** Notification category */
+  category: NotificationCategory;
+  /** Default priority */
+  priority: 'low' | 'medium' | 'high' | 'critical';
+  /** Default notification type */
+  type: 'changelog' | 'message';
+  /** Title template with variables */
+  title: string;
+  /** Content template with variables */
+  content: string;
+  /** Template variables */
+  variables: TemplateVariable[];
+  /** Default target roles */
+  defaultTargetRoles: string[];
+  /** Template tags for categorization */
+  tags: string[];
+}
+
+export interface TemplateVariable {
+  /** Variable name (without braces) */
+  name: string;
+  /** Variable description */
+  description: string;
+  /** Variable type */
+  type: 'string' | 'number' | 'date' | 'url' | 'email';
+  /** Whether variable is required */
+  required: boolean;
+  /** Default value if any */
+  defaultValue?: string;
+  /** Example value */
+  example?: string;
+}

--- a/lib/types/notification-admin.ts
+++ b/lib/types/notification-admin.ts
@@ -1,0 +1,37 @@
+import type { NotificationCategory } from './notification-center';
+
+export interface NotificationForm {
+  id?: string;
+  type: 'changelog' | 'message';
+  category: NotificationCategory;
+  title: string;
+  content: string;
+  priority: 'low' | 'medium' | 'high' | 'critical';
+  target_roles: string[];
+  target_users: string[];
+  scheduled_time?: string;
+  published?: boolean;
+  published_at?: string | null;
+}
+
+export interface NotificationTemplate {
+  title: string;
+  content: string;
+  category: NotificationCategory;
+  priority: 'low' | 'medium' | 'high' | 'critical';
+}
+
+export interface CategoryOption {
+  label: string;
+  description: string;
+}
+
+export interface PriorityOption {
+  label: string;
+  description: string;
+}
+
+export interface RoleOption {
+  value: string;
+  label: string;
+}


### PR DESCRIPTION
## What & Why

**What**: Add foundational type definitions and constants for notification system refactor
**Why**: Provide the core types and constants that other notification modules will depend on

This is PR1 in the notification system refactor series - establishing the foundation types before building other modules.

Fixes #(issue number)

## Pre-PR Checklist

Run these:

- [x] `pnpm type-check`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm i18n:check` (if applicable)

## Type

- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [ ] 💥 Breaking change
- [ ] 📚 Docs
- [x] ♻️ Refactor
- [ ] ⚡ Performance

## Details

**Files added:**
- `lib/types/notification-admin.ts` - Core interface definitions for notification forms, templates, and options
- `lib/constants/notification-admin.ts` - Static variables and default values for notifications  
- `lib/templates/types.ts` - Template system type definitions with variable support

**Changes:**
- ✅ Add `NotificationForm` interface for admin notification creation
- ✅ Add `NotificationTemplate` interface for template definitions
- ✅ Add option interfaces for categories, priorities, and roles
- ✅ Add `NOTIFICATION_VARIABLES` constant for content insertion
- ✅ Add `DEFAULT_NOTIFICATION_FORM` for form initialization
- ✅ Add template system types with variable definitions

**Lines of code:** ~115 lines across 3 files