### PR TITLE
feat(sso): add configurable email domain for SSO providers

### DIFF
--- a/app/api/sso/[providerId]/callback/route.ts
+++ b/app/api/sso/[providerId]/callback/route.ts
@@ -110,7 +110,10 @@ export async function GET(
     const casFullConfig = await CASConfigService.getCASConfig(providerId);
 
     // find or create user
-    let user = await SSOUserService.findUserByEmployeeNumber(employeeNumberStr);
+    let user = await SSOUserService.findUserByEmployeeNumber(
+      employeeNumberStr,
+      casFullConfig.emailDomain
+    );
 
     if (!user) {
       console.log(
@@ -142,8 +145,9 @@ export async function GET(
       await SSOUserService.updateLastLogin(user.id);
     }
 
-    // use email domain from config
-    const userEmail = `${user.employee_number || employeeNumberStr}@${casFullConfig.emailDomain}`;
+    // use email domain from provider settings
+    const emailDomain = casFullConfig.emailDomain || 'sso.local';
+    const userEmail = `${user.employee_number || employeeNumberStr}@${emailDomain}`;
 
     console.log(
       `Preparing to create Supabase session for user: ${user.id}, email: ${userEmail}`

--- a/components/admin/sso-providers/sso-provider-form.tsx
+++ b/components/admin/sso-providers/sso-provider-form.tsx
@@ -657,6 +657,36 @@ export function SsoProviderForm({
                             placeholder={t('fields.buttonTextPlaceholder')}
                           />
                         </div>
+
+                        {/* Email Domain */}
+                        <div>
+                          <label
+                            className={cn(
+                              'mb-2 block font-serif text-sm font-medium',
+                              isDark ? 'text-stone-300' : 'text-stone-700'
+                            )}
+                          >
+                            {t('fields.emailDomain')}
+                          </label>
+                          <input
+                            type="text"
+                            value={formData.settings.email_domain || ''}
+                            onChange={e =>
+                              handleSettingsChange(
+                                'email_domain',
+                                e.target.value || 'sso.local'
+                              )
+                            }
+                            className={cn(
+                              'w-full rounded-lg border px-4 py-3 font-serif text-sm transition-colors',
+                              'focus:ring-2 focus:ring-offset-2 focus:outline-none',
+                              isDark
+                                ? 'border-stone-600 bg-stone-800/50 text-stone-200 focus:border-stone-500 focus:ring-stone-500/30 focus:ring-offset-stone-900'
+                                : 'border-stone-300 bg-stone-50/50 text-stone-900 focus:border-stone-400 focus:ring-stone-400/30 focus:ring-offset-white'
+                            )}
+                            placeholder={t('fields.emailDomainPlaceholder')}
+                          />
+                        </div>
                       </div>
 
                       {/* Enable Provider */}

--- a/lib/services/admin/user/sso-user-service.ts
+++ b/lib/services/admin/user/sso-user-service.ts
@@ -28,7 +28,8 @@ export class SSOUserService {
    * @returns User profile or null
    */
   static async findUserByEmployeeNumber(
-    employeeNumber: string
+    employeeNumber: string,
+    emailDomain?: string
   ): Promise<Profile | null> {
     if (!employeeNumber || typeof employeeNumber !== 'string') {
       throw new Error('Employee number is required and must be a string');
@@ -37,10 +38,9 @@ export class SSOUserService {
     try {
       const supabase = await createClient();
 
-      // Construct SSO user's email address (employeeNumber@domain)
-      // Lookup by email, as the email field will be set correctly by trigger
-      // Note: This method is for lookup only; actual email should be from SSO provider config
-      const email = `${employeeNumber.trim()}@edu.cn`;
+      // Construct SSO user's email address using provided domain or fallback
+      const domain = emailDomain || 'sso.local';
+      const email = `${employeeNumber.trim()}@${domain}`;
       console.log(
         `Looking up user by email: ${email} (for employee: ${employeeNumber})`
       );
@@ -204,7 +204,8 @@ export class SSOUserService {
 
       // Create auth.users record using Supabase Admin API
       // This will also trigger creation of profiles record via trigger
-      const email = `${userData.employeeNumber}@${userData.emailDomain}`; // Use employee number and provider domain to generate email
+      const emailDomain = userData.emailDomain || 'sso.local';
+      const email = `${userData.employeeNumber}@${emailDomain}`; // Use employee number and configured domain to generate email
 
       console.log(
         `Creating auth user with email: ${email}, employee_number: ${userData.employeeNumber}`

--- a/lib/services/sso/generic-cas-service.ts
+++ b/lib/services/sso/generic-cas-service.ts
@@ -442,8 +442,7 @@ export class CASConfigService {
         full_name: protocolConfig.attributes_mapping?.full_name || 'cas:name',
         email: protocolConfig.attributes_mapping?.email || 'cas:mail',
       },
-      emailDomain:
-        this.extractEmailDomain(protocolConfig.base_url) || 'example.com',
+      emailDomain: provider.settings?.email_domain || 'sso.local',
     };
   }
 
@@ -508,23 +507,4 @@ export class CASConfigService {
     return new GenericCASService(config);
   }
 
-  /**
-   * extract email domain from base URL
-   * @private
-   * @param baseUrl CAS server base URL
-   * @returns email domain
-   */
-  private static extractEmailDomain(baseUrl: string): string {
-    try {
-      const url = new URL(baseUrl);
-      const hostname = url.hostname;
-      const parts = hostname.split('.');
-      if (parts.length >= 2) {
-        return parts.slice(-2).join('.');
-      }
-      return hostname;
-    } catch {
-      return 'example.com';
-    }
-  }
 }

--- a/lib/services/sso/generic-cas-service.ts
+++ b/lib/services/sso/generic-cas-service.ts
@@ -506,5 +506,4 @@ export class CASConfigService {
     const config = await this.getCASConfig(providerId);
     return new GenericCASService(config);
   }
-
 }

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -1698,6 +1698,8 @@
             "displayOrder": "Anzeigereihenfolge",
             "buttonText": "Schaltflächentext",
             "buttonTextPlaceholder": "Leer lassen, um den Anbieternamen zu verwenden",
+            "emailDomain": "E-Mail-Domain",
+            "emailDomainPlaceholder": "z.B. example.com",
             "enableProvider": "Diesen Anbieter aktivieren",
             "baseUrl": "Basis-URL",
             "baseUrlPlaceholder": "https://sso.example.com",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1698,6 +1698,8 @@
             "displayOrder": "Display Order",
             "buttonText": "Button Text",
             "buttonTextPlaceholder": "Leave blank to use provider name",
+            "emailDomain": "Email Domain",
+            "emailDomainPlaceholder": "e.g., example.com",
             "enableProvider": "Enable this provider",
             "baseUrl": "Base URL",
             "baseUrlPlaceholder": "https://sso.example.com",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -1698,6 +1698,8 @@
             "displayOrder": "Orden de visualización",
             "buttonText": "Texto del botón",
             "buttonTextPlaceholder": "Dejar en blanco para usar el nombre del proveedor",
+            "emailDomain": "Dominio de correo",
+            "emailDomainPlaceholder": "ej. example.com",
             "enableProvider": "Habilitar este proveedor",
             "baseUrl": "URL base",
             "baseUrlPlaceholder": "https://sso.example.com",

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -1698,6 +1698,8 @@
             "displayOrder": "Ordre d'affichage",
             "buttonText": "Texte du bouton",
             "buttonTextPlaceholder": "Laisser vide pour utiliser le nom du fournisseur",
+            "emailDomain": "Domaine de courriel",
+            "emailDomainPlaceholder": "ex: example.com",
             "enableProvider": "Activer ce fournisseur",
             "baseUrl": "URL de base",
             "baseUrlPlaceholder": "https://sso.example.com",

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -1698,6 +1698,8 @@
             "displayOrder": "Ordine di visualizzazione",
             "buttonText": "Testo pulsante",
             "buttonTextPlaceholder": "Lascia vuoto per usare il nome del fornitore",
+            "emailDomain": "Dominio email",
+            "emailDomainPlaceholder": "es. example.com",
             "enableProvider": "Abilita questo fornitore",
             "baseUrl": "URL di base",
             "baseUrlPlaceholder": "https://sso.example.com",

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -1698,6 +1698,8 @@
             "displayOrder": "表示順序",
             "buttonText": "ボタンテキスト",
             "buttonTextPlaceholder": "空白のままにするとプロバイダー名が使用されます",
+            "emailDomain": "メールドメイン",
+            "emailDomainPlaceholder": "例: example.com",
             "enableProvider": "このプロバイダーを有効にする",
             "baseUrl": "ベースURL",
             "baseUrlPlaceholder": "https://sso.example.com",

--- a/messages/pt-PT.json
+++ b/messages/pt-PT.json
@@ -1698,6 +1698,8 @@
             "displayOrder": "Ordem de exibição",
             "buttonText": "Texto do botão",
             "buttonTextPlaceholder": "Deixe em branco para usar o nome do provedor",
+            "emailDomain": "Domínio de email",
+            "emailDomainPlaceholder": "ex: example.com",
             "enableProvider": "Habilitar este provedor",
             "baseUrl": "URL Base",
             "baseUrlPlaceholder": "https://sso.example.com",

--- a/messages/ru-RU.json
+++ b/messages/ru-RU.json
@@ -1698,6 +1698,8 @@
             "displayOrder": "Порядок отображения",
             "buttonText": "Текст кнопки",
             "buttonTextPlaceholder": "Оставьте пустым, чтобы использовать название провайдера",
+            "emailDomain": "Домен электронной почты",
+            "emailDomainPlaceholder": "например: example.com",
             "enableProvider": "Включить этого провайдера",
             "baseUrl": "Базовый URL",
             "baseUrlPlaceholder": "https://sso.example.com",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -1698,6 +1698,8 @@
             "displayOrder": "显示顺序",
             "buttonText": "按钮文本",
             "buttonTextPlaceholder": "留空则使用提供商名称",
+            "emailDomain": "邮箱域名",
+            "emailDomainPlaceholder": "例如：example.com",
             "enableProvider": "启用此提供商",
             "baseUrl": "基础URL",
             "baseUrlPlaceholder": "https://sso.example.com",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1698,6 +1698,8 @@
             "displayOrder": "顯示順序",
             "buttonText": "按鈕文字",
             "buttonTextPlaceholder": "留空則使用服務商名稱",
+            "emailDomain": "電郵網域",
+            "emailDomainPlaceholder": "例如：example.com",
             "enableProvider": "啟用此服務商",
             "baseUrl": "基礎 URL",
             "baseUrlPlaceholder": "https://sso.example.com",


### PR DESCRIPTION
## What & Why

**What**: Add configurable email domain field for SSO providers
**Why**: Allow administrators to customize email domains for each SSO provider instead of auto-extracting from URLs

Fixes #272

## Pre-PR Checklist

Run these:

- [x] `pnpm type-check`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm i18n:check` (if applicable)

## Type

- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [ ] 💥 Breaking change
- [ ] 📚 Docs
- [ ] ♻️ Refactor
- [ ] ⚡ Performance

## Screenshots (if UI changes)

Added email domain configuration field in SSO provider settings form.