### PR TITLE
feat(storage): add content-images storage bucket for admin content editor

### DIFF
--- a/supabase/migrations/20250930172735_setup_content_images_storage.sql
+++ b/supabase/migrations/20250930172735_setup_content_images_storage.sql
@@ -14,9 +14,9 @@ VALUES (
   ARRAY['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/gif']
 )
 ON CONFLICT (id) DO UPDATE SET
-  public = true,
-  file_size_limit = 10485760,
-  allowed_mime_types = ARRAY['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/gif'];
+  public = EXCLUDED.public,
+  file_size_limit = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
 
 -- --- BEGIN COMMENT ---
 -- 2. Create RLS policies for Storage Objects
@@ -47,16 +47,14 @@ FOR SELECT USING (
 CREATE POLICY "content_images_update_policy" ON storage.objects
 FOR UPDATE USING (
   bucket_id = 'content-images'
-  AND auth.uid() IS NOT NULL
-  AND (storage.foldername(name))[1] = CONCAT('user-', auth.uid()::text)
+  AND auth.uid() = owner
 );
 
 -- Delete policy: users can only delete their own content images
 CREATE POLICY "content_images_delete_policy" ON storage.objects
 FOR DELETE USING (
   bucket_id = 'content-images'
-  AND auth.uid() IS NOT NULL
-  AND (storage.foldername(name))[1] = CONCAT('user-', auth.uid()::text)
+  AND auth.uid() = owner
 );
 
 -- --- BEGIN COMMENT ---


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Read [CONTRIBUTING.md](../CONTRIBUTING.md)
> 2. Ensure issue exists and you're assigned
> 3. Link correctly: `Fixes #<issue number>`

## What & Why

**What**: Add Supabase Storage bucket infrastructure for local image uploads in the admin content editor

**Why**: Currently, the admin content editor's image component only supports external URLs (like Unsplash). This PR creates the foundational storage infrastructure to enable users to upload and manage their own local images directly within the platform, reducing dependency on external image hosting services.

Fixes #250

## Pre-PR Checklist

Run these:

- [x] `pnpm type-check`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm i18n:check` (if applicable - N/A, no i18n changes)

## Type

- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [ ] 💥 Breaking change
- [ ] 📚 Docs
- [ ] ♻️ Refactor
- [ ] ⚡ Performance

## Changes

### Database Migration
- Create `content-images` storage bucket with public access
- Set file size limit to 10MB (larger than avatar bucket's 5MB)
- Support image formats: JPEG, PNG, WebP, GIF
- Add RLS policies for authenticated users:
  - **Upload**: Users can only upload to `user-{userId}/` folder
  - **Select**: Public read access (anyone can view images via URL)
  - **Update**: Users can only update their own files
  - **Delete**: Users can only delete their own files

### Technical Details
**File**: `supabase/migrations/20250930172735_setup_content_images_storage.sql`

**Bucket Configuration**:
```sql
bucket_id: 'content-images'
public: true  -- ✅ Images accessible via public URL
file_size_limit: 10485760 bytes (10MB)
allowed_mime_types: ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/gif']
```

**Path Structure**: `user-{userId}/{timestamp}-{uuid}.{ext}`

**Security**: RLS policies ensure users can only manage files in their own directories while maintaining public read access for displaying images on content pages.

## Implementation Plan

This is **PR #1** of a 5-part implementation:
- ✅ **PR #1** (this): Storage bucket infrastructure
- 🔜 **PR #2**: Upload service and React hook
- 🔜 **PR #3**: Image upload dialog component
- 🔜 **PR #4**: Integration with content editor
- 🔜 **PR #5** (optional): Image library management

## Testing Notes

- Migration syntax validated
- Follows existing pattern from `avatars` bucket
- Type checking passed
- No breaking changes to existing functionality